### PR TITLE
Update to 2.18.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
-{% set version = "2.17.0" %}
-{% set sha256 = "b21f009e52eb22b02b839f3bf2ae5374aaf0886317313c1358c6014e5383b539" %}
+{% set version = "2.18.0" %}
 
 package:
   name: imageio
@@ -7,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/imageio/imageio-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 090898c48532631ab11c74ae743e64c24dabda45c16db46f7e3bec9e2d8f422f
 
 build:
   number: 0


### PR DESCRIPTION
Seems the bot is down.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
