### PR TITLE
Pin av!=10.0.0 to avoid PyAV-Org/PyAV#1045 (cf. imageio/imageio#912)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
     - freeimage
     - fsspec
     - requests
-    - av
+    - av !=10.0.0
     #- opencv
     - imageio-ffmpeg
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - xfail-known-issues.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
   entry_points:

--- a/recipe/xfail-known-issues.patch
+++ b/recipe/xfail-known-issues.patch
@@ -34,15 +34,3 @@ index 2670138..ab1ae11 100644
  def test_exr_write():
      expected = np.full((128, 128, 3), 0.42, dtype=np.float32)
      buffer = iio3.imwrite("<bytes>", expected, extension=".exr")
-diff --git a/tests/test_pyav.py b/tests/test_pyav.py
-index 2f72031..8f107bd 100644
---- a/tests/test_pyav.py
-+++ b/tests/test_pyav.py
-@@ -439,6 +439,7 @@ def test_procedual_writing_with_filter(test_images):
-     assert actual.shape == (280, 480, 640, 3)
- 
- 
-+@pytest.mark.xfail
- def test_rotation_flag_metadata(test_images, tmp_path):
-     with iio.imopen(tmp_path / "test.mp4", "w", plugin="pyav") as file:
-         file.init_video_stream("libx264")


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This MR will pin `av!=10.0.0` to avoid PyAV-Org/PyAV#1045 (cf. imageio/imageio#912)